### PR TITLE
Add caching layer for data request

### DIFF
--- a/app/api/endpoints/data.py
+++ b/app/api/endpoints/data.py
@@ -112,7 +112,7 @@ async def view_data_stream_dataset(data_stream: str) -> Any:
 
 
 @router.get("/job/{uid}")
-def get_job(uid: str, version: str = str(settings.CURRENT_API_VERSION)):
+async def get_job(uid: str, version: str = str(settings.CURRENT_API_VERSION)):
     try:
         task = perform_fetch_task.AsyncResult(uid)
         response = {}
@@ -226,7 +226,7 @@ def data_request_check(request: Request, data_request: DataRequest):
 
 
 @router.post("/", status_code=202)
-def request_data(request: Request, data_request: DataRequest):
+async def request_data(request: Request, data_request: DataRequest):
     try:
         task = perform_fetch_task.apply_async(args=(data_request.dict(),))
         request_uuid = task.id

--- a/app/api/workers/data_fetcher.py
+++ b/app/api/workers/data_fetcher.py
@@ -287,10 +287,6 @@ def fetch(
     max_nfiles=50,
     max_partition_sizes={'netcdf': '100MB', 'csv': '10MB'},
 ):
-    self.update_state(
-        state="PROGRESS",
-        meta=status_dict,
-    )
     ds_list = get_delayed_ds(request_params, axis_params)
 
     status_dict.update({"msg": f"{len(request_params)} datasets requested."})
@@ -305,39 +301,43 @@ def fetch(
     client = None
     cluster = None
 
-    if max_mem_size > data_threshold:
-        image_repo, image_name, image_tag = (
-            'cormorack',
-            'cava-dask',
-            '20210610',
-        )
-        desired_image = os.environ.get(
-            "DASK_DOCKER_IMAGE", f"{image_repo}/{image_name}:{image_tag}"
-        )
-        match = re.match(r"(.+)/(.+):(.+)", desired_image)
-        if match is not None:
-            image_repo, image_name, image_tag = match.groups()
-        dask_spec = determine_workers(
-            max_mem_size,
-            image_repo=image_repo,
-            image_name=image_name,
-            image_tag=image_tag,
-        )
+    # TODO: Figure out using distributed from a 
+    #       central dask cluster
+    # if max_mem_size > data_threshold:
+    #     image_repo, image_name, image_tag = (
+    #         'cormorack',
+    #         'cava-dask',
+    #         '20210610',
+    #     )
+    #     desired_image = os.environ.get(
+    #         "DASK_DOCKER_IMAGE", f"{image_repo}/{image_name}:{image_tag}"
+    #     )
+    #     match = re.match(r"(.+)/(.+):(.+)", desired_image)
+    #     if match is not None:
+    #         image_repo, image_name, image_tag = match.groups()
+    #     dask_spec = determine_workers(
+    #         max_mem_size,
+    #         image_repo=image_repo,
+    #         image_name=image_name,
+    #         image_tag=image_tag,
+    #     )
 
-        status_dict.update(
-            {
-                "msg": f"Setting up distributed computing cluster. Max data size: {memory_repr(max_data_size)}"
-            }
-        )
-        self.update_state(state="PROGRESS", meta=status_dict)
-        cluster = KubeCluster(
-            dask_spec['pod_spec'],
-            n_workers=dask_spec['min_workers'],
-        )
-        cluster.adapt(
-            minimum=dask_spec['min_workers'], maximum=dask_spec['max_workers']
-        )
-        client = Client(cluster)
+    #     status_dict.update(
+    #         {
+    #             "msg": f"Setting up distributed computing cluster. Max data size: {memory_repr(max_data_size)}"
+    #         }
+    #     )
+    #     self.update_state(state="PROGRESS", meta=status_dict)
+    #     cluster = KubeCluster(
+    #         dask_spec['pod_spec'],
+    #         n_workers=dask_spec['min_workers'],
+    #     )
+    #     cluster.adapt(
+    #         minimum=dask_spec['min_workers'], maximum=dask_spec['max_workers']
+    #     )
+    #     client = Client(cluster)
+
+
     # TODO: Need to add other parameters for multidimensional
     # need a check for nutnr,pco2,ph,optaa add int_ctd_pressure
     # parameters.append("int_ctd_pressure")

--- a/app/api/workers/tasks.py
+++ b/app/api/workers/tasks.py
@@ -1,10 +1,37 @@
+from typing import Any, Dict
+import asyncio
+import functools
+import msgpack
+
+from loguru import logger
+
 from app.core.celery_app import celery_app
 from celery.exceptions import SoftTimeLimitExceeded
 from .data_fetcher import fetch
+from app.cache.redis import redis_dependency
+from app.models import DataRequest
+
+
+def sync(f):
+    """Decorater to make async to sync for a solo pool within celery worker"""
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        return asyncio.get_event_loop().run_until_complete(f(*args, **kwargs))
+
+    return wrapper
 
 
 @celery_app.task(bind=True)
-def perform_fetch_task(self, data_request):
+@sync
+async def perform_fetch_task(
+    self,
+    data_request: Dict[str, Any],
+):
+    cache = await redis_dependency()
+    data_request_object = DataRequest(**data_request)
+    cache_key = data_request_object._key
+    cached_result = await cache.get(cache_key)
+
     try:
         request_params = data_request["ref"].split(",")
         download = data_request.get('download', False)
@@ -26,18 +53,32 @@ def perform_fetch_task(self, data_request):
             "type": job_type,
             "msg": "Data retrieval started.",
         }
+        self.update_state(
+            state="PROGRESS",
+            meta=status_dict,
+        )
         start_dt = data_request['start_dt']
         end_dt = data_request['end_dt']
-        result = fetch(
-            self,
-            request_params,
-            axis_params,
-            start_dt,
-            end_dt,
-            download,
-            download_format,
-            status_dict,
-        )
+        if cached_result is not None:
+            logger.info("Using cached result.")
+            status_dict.update({"msg": "Using cached data."})
+            self.update_state(state="PROGRESS", meta=status_dict)
+            result = msgpack.unpackb(cached_result)
+            logger.info("Result done.")
+        else:
+            logger.info("Fetching new result.")
+            result = fetch(
+                self,
+                request_params,
+                axis_params,
+                start_dt,
+                end_dt,
+                download,
+                download_format,
+                status_dict,
+            )
+            # Cache the result for 1 hour
+            await cache.set(cache_key, msgpack.packb(result), ex=3600)
         if result is not None:
             if job_type == "download" and result["file_url"] is None:
                 return {

--- a/app/cache/redis.py
+++ b/app/cache/redis.py
@@ -1,0 +1,37 @@
+import aioredis
+from aioredis.exceptions import ConnectionError
+from typing import Optional
+from app.core.config import settings
+import time
+import logging
+
+logger = logging.getLogger('uvicorn')
+logging.root.setLevel(level=logging.INFO)
+
+
+class RedisDependency:
+    """FastAPI Dependency for Redis Connections"""
+
+    redis: Optional[aioredis.client.Redis] = None
+    connected: bool = False
+
+    async def __call__(self):
+        if self.redis is None:
+            await self.init()
+        return self.redis
+
+    async def init(self):
+        """Initialises the Redis Dependency"""
+        self.redis = await aioredis.from_url(settings.REDIS_URI)
+
+        while not self.connected:
+            try:
+                await self.redis.ping()
+                self.connected = True
+                logger.info("Redis connected!")
+            except ConnectionError:
+                logger.warning("Not connected to Redis. Trying again.")
+                time.sleep(5)
+
+
+redis_dependency: RedisDependency = RedisDependency()

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from .api.main import api_router
 from .api.endpoints import data
 from .core.config import settings
 from .scripts import LoadDataCatalog, LoadShipData
+from .cache.redis import RedisDependency
 
 logging.root.setLevel(level=logging.INFO)
 logger = logging.getLogger('uvicorn')
@@ -49,6 +50,7 @@ app.mount("/data/static", app.state.static, name="static")
 @app.on_event("startup")
 async def startup_event():
     LoadDataCatalog()
+    await RedisDependency().init()
     # LoadShipData()
 
 # Prometheus instrumentation

--- a/app/models.py
+++ b/app/models.py
@@ -1,9 +1,11 @@
 import os
+import json
+import hashlib
 
 import xarray as xr
 import xpublish  # noqa
 
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 from typing import Optional
 from .core.config import settings
 
@@ -18,6 +20,17 @@ class DataRequest(BaseModel):
     color: str = ""
     download_format: str = "netcdf"
     download: bool = False
+
+    _key: str = PrivateAttr()
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._set_key()
+
+    def _set_key(self):
+        encoded_json = json.dumps(self.dict()).encode('utf-8')
+        md5_hash = hashlib.md5(encoded_json)
+        self._key = md5_hash.hexdigest()
 
 
 class CancelConfig(BaseModel):

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,19 +12,20 @@ dependencies:
   - uvicorn
   - gunicorn
   - redis-py
-  - xarray<0.18
+  - aioredis
+  - msgpack-python
+  - xarray
   - zarr
   - dask
   - dask-kubernetes
   - netcdf4
-  - s3fs==0.5.2
-  - aiobotocore==1.2.1
+  - s3fs
   - intake
   - intake-xarray
   - numcodecs
   - datashader
   - hvplot
-  - fsspec==0.8.7
+  - fsspec
   - numba
   - numpy
   - pip
@@ -37,6 +38,6 @@ dependencies:
   - celery
   - pika
   - prometheus-fastapi-instrumentator
-  - pip=20
+  - pip=22
   - pip:
     - git+https://github.com/jhamman/xpublish.git@master

--- a/resources/docker/docker-compose.yaml
+++ b/resources/docker/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - LOOP=asyncio
       - HTTP=h11
       - GOOGLE_SERVICE_JSON=${GOOGLE_SERVICE_JSON}
+      - REDIS_URI=redis://redis-service
     networks:
       - cava-network
   celery-worker:


### PR DESCRIPTION
## Overview

This PR adds caching layer for data requests to make it faster. The following changes has been made to make this happen:
- [X] Add `msgpack` and `aioredis` to dependencies
- [X] Setup redis connections through the use of `REDIS_URI` similarly to the data workers
- [X] Use msgpack for encoding and decoding cached results
- [X] Add version `2.1` of `/data/job` endpoint to utilize msgpack media type.
- [X] Limit user request to not exceed pod memory size.