### PR TITLE
Use gunicorn to manage uvicorn

### DIFF
--- a/cava_data/cli.py
+++ b/cava_data/cli.py
@@ -1,15 +1,50 @@
-import uvicorn
+from gunicorn.app.base import BaseApplication
 from cava_data.core.config import settings
 
 
+class StandaloneApplication(BaseApplication):
+    def __init__(self, app, options=None):
+        self.options = options or {}
+        self.application = app
+        super().__init__()
+
+    def load_config(self):
+        config = {
+            key: value
+            for key, value in self.options.items()
+            if key in self.cfg.settings and value is not None
+        }
+        for key, value in config.items():
+            self.cfg.set(key.lower(), value)
+
+    def load(self):
+        return self.application
+
+
 def serve():
-    uvicorn.run(
-        "cava_data.main:app",
-        host=settings.HOST,
-        port=settings.PORT,
-        log_level=settings.LOG_LEVEL,
-        loop=settings.LOOP,
-        http=settings.HTTP,
-        workers=settings.WORKERS,
-        reload=settings.DEVELOPMENT
-    )
+    if not settings.DEVELOPMENT:
+        from cava_data.main import app
+        options = {
+            'bind': f"{settings.HOST}:{settings.PORT}",
+            'host': settings.HOST,
+            'port': settings.PORT,
+            'workers': settings.WORKERS,
+            'worker_class': settings.WORKER_CLASS,
+            'loglevel': settings.LOG_LEVEL,
+            'graceful_timeout': settings.GRACEFUL_TIMEOUT,
+            'timeout': settings.TIMEOUT,
+            'keepalive': settings.KEEP_ALIVE,
+        }
+        StandaloneApplication(app, options).run()
+    else:
+        import uvicorn
+        uvicorn.run(
+            "cava_data.main:app",
+            host=settings.HOST,
+            port=settings.PORT,
+            log_level=settings.LOG_LEVEL,
+            loop=settings.LOOP,
+            http=settings.HTTP,
+            workers=settings.WORKERS,
+            reload=settings.DEVELOPMENT
+        )

--- a/cava_data/core/config.py
+++ b/cava_data/core/config.py
@@ -55,19 +55,23 @@ class Settings(BaseSettings):
     DATA_CATALOG_FILE: str = "https://ooi-data.github.io/catalog.yaml"
 
     # Message queue
-    RABBITMQ_URI: str = "amqp://guest@rabbitmq-service:5672//"
+    RABBITMQ_URI: str = "amqp://guest@localhost:5672//"
 
     # Cache service
-    REDIS_URI: str = "redis://redis-service"
+    REDIS_URI: str = "redis://localhost"
 
-    # Uvicorn config
+    # Uvicorn/Gunicorn config
     HOST: str = "0.0.0.0"
     PORT: int = 80
-    LOG_LEVEL: str = "info"
+    LOG_LEVEL: str = "debug"
     LOOP: str = "auto"
     HTTP: str = "auto"
     WORKERS: int = 1
     DEVELOPMENT: bool = False
+    GRACEFUL_TIMEOUT: str = "120"
+    TIMEOUT: str = "120"
+    KEEP_ALIVE: str = "5"
+    WORKER_CLASS: str = "uvicorn.workers.UvicornWorker"
 
 
 settings = Settings()

--- a/cava_data/core/config.py
+++ b/cava_data/core/config.py
@@ -63,7 +63,7 @@ class Settings(BaseSettings):
     # Uvicorn/Gunicorn config
     HOST: str = "0.0.0.0"
     PORT: int = 80
-    LOG_LEVEL: str = "debug"
+    LOG_LEVEL: str = "info"
     LOOP: str = "auto"
     HTTP: str = "auto"
     WORKERS: int = 1

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,6 +6,7 @@ dependencies:
   - cytoolz
   - lz4
   - nomkl
+  - gevent
   - fastapi
   - aiofiles
   - uvicorn

--- a/resources/docker/docker-compose.yaml
+++ b/resources/docker/docker-compose.yaml
@@ -11,11 +11,16 @@ services:
       - 8787:8787
     volumes:
       - ../../:/app/:consistent
+    links:
+      - "celery-worker:celery-worker"
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - GOOGLE_SERVICE_JSON=${GOOGLE_SERVICE_JSON}
       - REDIS_URI=redis://redis-service
+      - RABBITMQ_URI=amqp://guest@rabbitmq-service:5672//
+      - WORKERS=2
+      - LOG_LEVEL=info
     networks:
       - cava-network
   celery-worker:
@@ -25,7 +30,10 @@ services:
     image: cormorack/cava-data:${TAG}
     deploy:
       replicas: 2
-    command: celery -A cava_data.api.workers.tasks worker -E -l info -Q data-queue -c 1 -P solo
+    command: celery -A cava_data.api.workers.tasks worker -E -l info -Q data-queue -c 1 -P gevent
+    links:
+      - "redis-service:redis-service"
+      - "rabbitmq-service:rabbitmq-service"
     volumes:
       - ../../:/app/:consistent
     environment:

--- a/resources/helm/cava-data/templates/worker-deployment.yaml
+++ b/resources/helm/cava-data/templates/worker-deployment.yaml
@@ -37,27 +37,19 @@ spec:
             {{- toYaml .Values.worker.extra_env | nindent 12 }}
           {{- end }}
           args:
-            - celery 
+            - celery
             - -A
-            {{- if .Values.worker.custom_tasks }}
-            - {{ .Values.worker.custom_tasks }}
-            {{- else }}
-            - cava_data.api.workers.tasks
-            {{- end }} 
-            - worker 
+            - {{ .Values.worker.tasks | default "cava_data.api.workers.tasks" }}
+            - worker
             - -E
-            - -l 
-            - info 
+            - -l
+            - {{ .Values.worker.log_level | default "info" }}
             - -Q
-            {{- if .Values.worker.custom_queue }}
-            - {{ .Values.worker.custom_queue }}
-            {{- else }}
-            - data-queue
-            {{- end }} 
-            - -c 
+            - {{ .Values.worker.queue | default "data-queue" }}
+            - -c
             - "1"
             - -P
-            - "solo"
+            - {{ .Values.worker.pool | default "gevent" }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:

--- a/resources/helm/cava-data/values.yaml
+++ b/resources/helm/cava-data/values.yaml
@@ -68,6 +68,10 @@ worker:
     - name: RABBITMQ_URI
       value: "amqp://guest@cava-data-rabbitmq:5672//"
   resources: {}
+  pool: "gevent"
+  log_level: "info"
+  queue: "data-queue"
+  tasks: "cava_data.api.workers.tasks"
 
 rabbitmq:
   enabled: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ install_requires =
   fastapi
   aiofiles
   uvicorn
+  gunicorn
+  gevent
   redis
   aioredis
   msgpack


### PR DESCRIPTION
This PR uses gunicorn to manage uvicorn to make it more robust. This also updates data worker to use gevent pool to utilize eventlet.