### PR TITLE
Setup config to utilize dsn and be able to use SQS

### DIFF
--- a/cava_data/cache/redis.py
+++ b/cava_data/cache/redis.py
@@ -22,7 +22,7 @@ class RedisDependency:
 
     async def init(self):
         """Initialises the Redis Dependency"""
-        self.redis = await aioredis.from_url(settings.REDIS_URI)
+        self.redis = await aioredis.from_url(str(settings.REDIS_URI))
 
         while not self.connected:
             try:

--- a/cava_data/core/celeryconfig.py
+++ b/cava_data/core/celeryconfig.py
@@ -1,7 +1,11 @@
 import datetime
 from .config import settings
 
-broker_url = settings.RABBITMQ_URI
+broker_url = str(settings.RABBITMQ_URI)
+if settings.RABBITMQ_URI.scheme == 'sqs':
+    broker_transport_options = {
+        'region': 'us-west-2'
+    }
 
 task_routes = {
     "cava_data.api.workers.tasks.perform_fetch_task": {"queue": "data-queue"}
@@ -9,5 +13,5 @@ task_routes = {
 task_create_missing_queues = True
 
 # Results configs
-result_backend = settings.REDIS_URI
+result_backend = str(settings.REDIS_URI)
 result_expires = datetime.timedelta(hours=1)

--- a/cava_data/core/config.py
+++ b/cava_data/core/config.py
@@ -2,7 +2,12 @@ import os
 import fsspec
 
 from typing import Any, Dict, List
-from pydantic import BaseSettings
+from pydantic import BaseSettings, AnyUrl, RedisDsn
+
+
+class MessageQueue(AnyUrl):
+    allowed_schemes = {'sqs', 'amqp', 'amqps'}
+    host_required = False
 
 
 class Settings(BaseSettings):
@@ -55,10 +60,10 @@ class Settings(BaseSettings):
     DATA_CATALOG_FILE: str = "https://ooi-data.github.io/catalog.yaml"
 
     # Message queue
-    RABBITMQ_URI: str = "amqp://guest@localhost:5672//"
+    RABBITMQ_URI: MessageQueue = "amqp://guest@localhost:5672//"
 
     # Cache service
-    REDIS_URI: str = "redis://localhost"
+    REDIS_URI: RedisDsn = "redis://localhost"
 
     # Uvicorn/Gunicorn config
     HOST: str = "0.0.0.0"

--- a/environment.yaml
+++ b/environment.yaml
@@ -38,3 +38,5 @@ dependencies:
   - pika
   - prometheus-fastapi-instrumentator
   - watchgod
+  - setuptools<59
+  - wheel>=0.29.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -37,6 +37,7 @@ dependencies:
   - celery
   - pika
   - prometheus-fastapi-instrumentator
+  - pycurl
   - watchgod
   - setuptools<59
   - wheel>=0.29.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -37,7 +37,7 @@ dependencies:
   - celery
   - pika
   - prometheus-fastapi-instrumentator
-  - pycurl
+  - pycurl<7.45
   - watchgod
   - setuptools<59
   - wheel>=0.29.0

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -7,6 +7,6 @@ RUN mamba env update -n base -f /app/environment.yaml
 RUN conda info
 RUN conda list
 RUN which pip
-RUN pip install -e /app
+RUN pip install /app
 
 CMD [ "cava_data" ]

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -4,6 +4,9 @@ ARG PYTHON_VERSION=3.8
 FROM condaforge/mambaforge:${CONDA_VERSION}
 COPY ./ /app
 RUN mamba env update -n base -f /app/environment.yaml
-RUN which pip && pip install -e /app
+RUN conda info
+RUN conda list
+RUN which pip
+RUN pip install -e /app
 
 CMD [ "cava_data" ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
   redis
   aioredis
   msgpack
+  kombu
   xarray
   zarr
   dask
@@ -60,7 +61,7 @@ install_requires =
   toolz
   gspread
   loguru
-  celery
+  celery[sqs]
   pika
   prometheus-fastapi-instrumentator
   watchgod


### PR DESCRIPTION
This PR allows the use of Amazon SQS for queues and use dsn for Redis and Rabbitmq URI.