### PR TITLE
Move from aioredis to redis-py

### DIFF
--- a/cava_data/api/endpoints/data.py
+++ b/cava_data/api/endpoints/data.py
@@ -10,7 +10,7 @@ import msgpack
 import xarray as xr
 from dask.utils import memory_repr
 import numpy as np
-import aioredis
+import redis.asyncio as aioredis
 
 from cava_data.core.celery_app import celery_app
 from cava_data.core.celeryconfig import result_expires

--- a/cava_data/cache/redis.py
+++ b/cava_data/cache/redis.py
@@ -1,5 +1,5 @@
-import aioredis
-from aioredis.exceptions import ConnectionError
+from redis.exceptions import ConnectionError
+import redis.asyncio as aioredis
 from typing import Optional
 from cava_data.core.config import settings
 import time

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,8 +11,7 @@ dependencies:
   - aiofiles
   - uvicorn
   - gunicorn
-  - redis-py
-  - aioredis
+  - redis-py>=4.2
   - msgpack-python
   - xarray
   - zarr

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,7 @@ install_requires =
   uvicorn
   gunicorn
   gevent
-  redis
-  aioredis
+  redis>=4.2
   msgpack
   kombu
   xarray


### PR DESCRIPTION
`aioredis` is now a part of `redis-py`. This PR now moves our dependency to only `redis-py`.