### PR TITLE
Update s3 bucket names

### DIFF
--- a/cava_data/api/workers/models.py
+++ b/cava_data/api/workers/models.py
@@ -24,7 +24,7 @@ class OOIDataset:
     def __init__(
         self,
         dataset_id,
-        bucket_name="ooi-data",
+        bucket_name="ooi-data-prod",
         storage_options={'anon': True},
     ):
         self.dataset_id = dataset_id

--- a/cava_data/core/config.py
+++ b/cava_data/core/config.py
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
         ),
     }
 
-    DATA_BUCKET: str = 'ooi-data'
+    DATA_BUCKET: str = 'ooi-data-prod'
     CADAI_BUCKET: str = 'ooi-data-cadai'
     SHIP_DATA_FOLDER: str = 'ship_data'
     SHIP_DATA_SOURCE: str = f'{SHIP_DATA_FOLDER}/source.json'


### PR DESCRIPTION
This PR contains changes to update the s3 bucket names from the prefect 1 harvest to the new prefect 2 harvest. These new pointers will point to buckets on the rca-data s3 buckets instead of cava.