### PR TITLE
Update AWS lambda deployment from using cdk v1 to v2

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set Job Environment Variables
         run: |
           DOCKER_TAG=PR

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           DOCKER_TAG=PR
           IMAGE_SPEC="${DOCKER_ORG}/${{ env.IMAGE_NAME }}:${DOCKER_TAG}"
-          echo "IMAGE_SPEC=${IMAGE_SPEC}" >> $GITHUB_ENV
+          echo "IMAGE_SPEC=${IMAGE_SPEC}" >> "$GITHUB_ENV"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,6 +39,8 @@ jobs:
           push: false
           build-args: |
             CONDA_VERSION=${{ env.CONDA_VERSION }}
+            echo "CONDA_VERSION=${CONDA_VERSION}" >> "$GITHUB_ENV"
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            echo "PYTHON_VERSION=${PYTHON_VERSION}" >> "$GITUB_ENV"
           tags: |
             ${{ env.IMAGE_SPEC }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,12 +27,12 @@ jobs:
           IMAGE_SPEC="${DOCKER_ORG}/${{ env.IMAGE_NAME }}:${DOCKER_TAG}"
           echo "IMAGE_SPEC=${IMAGE_SPEC}" >> "$GITHUB_ENV"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Build Docker Image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./resources/docker/Dockerfile

--- a/resources/aws/README.md
+++ b/resources/aws/README.md
@@ -2,7 +2,7 @@
 
 The Lambda stack is also deployed by the [AWS CDK](https://aws.amazon.com/cdk/) utility. Under the hood, CDK will create the deployment package required for AWS Lambda, upload it to AWS, and handle the creation of the Lambda and API Gateway resources.
 
-This Lambda deployment is adapted from [Titler](https://github.com/developmentseed/titiler/tree/main/deployment). 
+This Lambda deployment is adapted from [Titiler](https://github.com/developmentseed/titiler/tree/main/deployment). 
 
 1. Install CDK and connect to your AWS account. This step is only necessary once per AWS account.
 

--- a/resources/aws/README.md
+++ b/resources/aws/README.md
@@ -2,6 +2,8 @@
 
 The Lambda stack is also deployed by the [AWS CDK](https://aws.amazon.com/cdk/) utility. Under the hood, CDK will create the deployment package required for AWS Lambda, upload it to AWS, and handle the creation of the Lambda and API Gateway resources.
 
+This Lambda deployment is adapted from [Titler](https://github.com/developmentseed/titiler/tree/main/deployment). 
+
 1. Install CDK and connect to your AWS account. This step is only necessary once per AWS account.
 
     ```bash
@@ -19,7 +21,7 @@ The Lambda stack is also deployed by the [AWS CDK](https://aws.amazon.com/cdk/) 
     npm run cdk synth  # Synthesizes and prints the CloudFormation template for this stack
     ```
 
-3. Update settings in a `.env` file.
+3. Update settings in a `.env` file. This is already set in `env.example` so you can go ahead and deploy the stack unless you want to add other settings. 
 
     ```env
     CAVA_DATA_STACK_NAME="cava-data"

--- a/resources/aws/cdk/app.py
+++ b/resources/aws/cdk/app.py
@@ -1,13 +1,11 @@
 """Construct App."""
 
 import os
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from aws_cdk import App, CfnOutput, Duration, Environment, Stack, Tag
 from aws_cdk import aws_apigatewayv2_alpha as apigw
 from aws_cdk import aws_ec2 as ec2
-from aws_cdk import aws_ecs as ecs
-from aws_cdk import aws_ecs_patterns as ecs_patterns
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda
 from aws_cdk import aws_logs as logs
@@ -23,9 +21,8 @@ class cavaDataLambdaStack(Stack):
     Titiler Lambda Stack
 
     This code is freely adapted from
-    - https://github.com/leothomas/titiler/blob/10df64fbbdd342a0762444eceebaac18d8867365/stack/app.py author: @leothomas
-    - https://github.com/ciaranevans/titiler/blob/3a4e04cec2bd9b90e6f80decc49dc3229b6ef569/stack/app.py author: @ciaranevans
-
+    - https://developmentseed.org/titiler/deployment/aws/lambda/ @developmentseed
+    - https://github.com/developmentseed/titiler/tree/main/deployment (Using the aws example)
     """
 
     def __init__(

--- a/resources/aws/cdk/app.py
+++ b/resources/aws/cdk/app.py
@@ -1,24 +1,26 @@
 """Construct App."""
 
 import os
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Union
 
-from aws_cdk import aws_certificatemanager as acm
-from aws_cdk import aws_apigatewayv2 as apigw
-from aws_cdk import aws_apigatewayv2_integrations as apigw_integrations
-from aws_cdk import aws_iam as iam
+from aws_cdk import App, CfnOutput, Duration, Environment, Stack, Tag
+from aws_cdk import aws_apigatewayv2_alpha as apigw
 from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_ecs_patterns as ecs_patterns
+from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda
 from aws_cdk import aws_logs as logs
-from aws_cdk import core
+from aws_cdk.aws_apigatewayv2_integrations_alpha import HttpLambdaIntegration
 from config import StackSettings
+from constructs import Construct
 
 settings = StackSettings()
 
 
-class cavaDataLambdaStack(core.Stack):
+class cavaDataLambdaStack(Stack):
     """
-    Cava Data Lambda Stack
+    Titiler Lambda Stack
 
     This code is freely adapted from
     - https://github.com/leothomas/titiler/blob/10df64fbbdd342a0762444eceebaac18d8867365/stack/app.py author: @leothomas
@@ -28,32 +30,27 @@ class cavaDataLambdaStack(core.Stack):
 
     def __init__(
         self,
-        scope: core.Construct,
+        scope: Construct,
         id: str,
         memory: int = 1024,
         timeout: int = 30,
         concurrent: Optional[int] = None,
         permissions: Optional[List[iam.PolicyStatement]] = None,
         environment: Optional[Dict] = None,
-        code_dir: str = "../../",
+        code_dir: str = "./",
         vpc: Optional[str] = None,
         security_group: Optional[str] = None,
         user_role: Optional[str] = None,
-        env: Optional[core.Environment] = None,
-        services_elb: Optional[str] = None,
-        extra_routes: Optional[Set] = None,
-        domain_name: Optional[str] = None,
-        certificate_arn: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Define stack."""
-        super().__init__(scope, id, env=env, **kwargs)
+        super().__init__(scope, id, **kwargs)
 
         permissions = permissions or []
         environment = environment or {}
         # Get IVpc
         security_groups = None
-        if vpc is not None:
+        if vpc is not None: 
             vpc = ec2.Vpc.from_lookup(self, f"{id}-vpc", vpc_id=vpc)
             if security_group is not None:
                 sg = ec2.SecurityGroup.from_lookup_by_id(self, f"{id}-sg", security_group_id=security_group)
@@ -63,11 +60,11 @@ class cavaDataLambdaStack(core.Stack):
             f"{id}-lambda",
             code=aws_lambda.DockerImageCode.from_image_asset(
                 directory=os.path.abspath(code_dir),
-                file="resources/aws/lambda/Dockerfile",
+                file="lambda/Dockerfile",
             ),
             memory_size=memory,
             reserved_concurrent_executions=concurrent,
-            timeout=core.Duration.seconds(timeout),
+            timeout=Duration.seconds(timeout),
             environment=environment,
             log_retention=logs.RetentionDays.ONE_WEEK,
             vpc=vpc,
@@ -81,40 +78,16 @@ class cavaDataLambdaStack(core.Stack):
         for perm in permissions:
             lambda_function.add_to_role_policy(perm)
 
-        # Setup custom domain mapping if available
-        default_domain_mapping = None
-        if domain_name is not None:
-            if certificate_arn is None:
-                raise ValueError("Certificate arn is missing, but you have provided domain name!")
-
-            custom_domain = apigw.DomainName(self, f"{id}-domain-name",
-                domain_name=domain_name,
-                certificate=acm.Certificate.from_certificate_arn(self, f"{id}-cert", certificate_arn)
-            )
-            default_domain_mapping = apigw.DomainMappingOptions(domain_name=custom_domain)
-
-        # Core API that combines all the services
-        core_api = apigw.HttpApi(self, f"{id}-core-api", default_domain_mapping=default_domain_mapping)
-        core_api.add_routes(
-            path="/data/{proxy+}",
-            integration=apigw_integrations.HttpLambdaIntegration(
-                f"{id}-data-proxy-integration", handler=lambda_function
+        api = apigw.HttpApi(
+            self,
+            f"{id}-endpoint",
+            default_integration=HttpLambdaIntegration(
+                f"{id}-integration", handler=lambda_function
             ),
         )
-        if services_elb is not None:
-            if extra_routes is not None:
-                for route in extra_routes:
-                    core_api.add_routes(
-                        path=f"/{route}/{{proxy+}}",
-                        integration=apigw_integrations.HttpUrlIntegration(
-                            f"{id}-{route}-integration",
-                            url=f"http://{services_elb}/{route}/{{proxy}}"
-                        )
-                    )
-        core.CfnOutput(self, "Endpoint", value=core_api.url)
+        CfnOutput(self, "Endpoint", value=api.url)
 
-
-app = core.App()
+app = App()
 
 perms = [
     iam.PolicyStatement(
@@ -134,45 +107,28 @@ if settings.is_sqs is True:
         )
     )
 
-
 # Tag infrastructure
 for key, value in {
-    "Name": settings.name,
+    "Project": settings.name,
     "Environment": settings.stage,
     "Owner": settings.owner,
     "Project": settings.project,
 }.items():
     if value:
-        core.Tag.add(app, key, value)
+        Tag(key, value)
 
-extra_routes = {
-    'metadata',
-    'media',
-    'feed',
-}
-
-
-lambda_stackname = f"{settings.name}-lambda-{settings.stage}"
-stack_env = core.Environment(
+stack_env = Environment(
     account=settings.account_id,
     region=settings.region
 )
-cavaDataLambdaStack(
+lambda_stack = cavaDataLambdaStack(
     app,
-    lambda_stackname,
+    f"{settings.name}-lambda-{settings.stage}",
     memory=settings.memory,
     timeout=settings.timeout,
     concurrent=settings.max_concurrent,
-    environment=settings.env,
     permissions=perms,
-    vpc=settings.vpc,
-    security_group=settings.security_group,
-    user_role=settings.user_role,
-    env=stack_env,
-    services_elb=settings.services_elb,
-    extra_routes=extra_routes,
-    domain_name=settings.domain_name,
-    certificate_arn=settings.certificate_arn,
+    environment=settings.env,
 )
 
 app.synth()

--- a/resources/aws/cdk/config.py
+++ b/resources/aws/cdk/config.py
@@ -1,34 +1,32 @@
 """CAVA_DATA_STACK Configs."""
-from typing import Dict, Optional
 
-import pydantic
+from typing import Dict, List, Optional
+
+from pydantic import model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class StackSettings(pydantic.BaseSettings):
+class StackSettings(BaseSettings):
     """Application settings"""
-
-    class Config:
-        """model config"""
-
-        env_file = ".env"
-        env_prefix = "CAVA_DATA_STACK_"
 
     name: str = "cava-data"
     stage: str = "production"
 
-    owner: Optional[str]
+    owner: Optional[str] = None
+    client: Optional[str] = None
+    owner: Optional[str] = None
     project: str = "CAVA"
 
-    vpc: Optional[str]
-    security_group: Optional[str]
-    user_role: Optional[str]
+    vpc: Optional[str] = None
+    security_group: Optional[str] = None
+    user_role: Optional[str] = None
 
     # Stack environment
     region: str = "us-west-2"
     account_id: str = "123556123145"
-    services_elb: str
-    domain_name: Optional[str]
-    certificate_arn: Optional[str]
+    # services_elb: str
+    domain_name: Optional[str] = None
+    certificate_arn: Optional[str] = None
 
     # Default options for cava-data service
     env: Dict = {
@@ -40,8 +38,6 @@ class StackSettings(pydantic.BaseSettings):
         "GOOGLE_SERVICE_JSON": "mybucket/service-json.json"
     }
     is_sqs: bool = False
-
-
     ###########################################################################
     # AWS LAMBDA
     # The following settings only apply to AWS Lambda deployment
@@ -51,22 +47,24 @@ class StackSettings(pydantic.BaseSettings):
 
     # The maximum of concurrent executions you want to reserve for the function.
     # Default: - No specific limit - account limit.
-    max_concurrent: Optional[int]
+    max_concurrent: Optional[int] = None
 
-    @pydantic.root_validator
-    def set_sqs(cls, values):
-        env_values = values.get('env')
-        rabbitmq_uri = env_values.get('RABBITMQ_URI')
-        if not isinstance(rabbitmq_uri, str):
-            raise TypeError("RABBITMQ_URI must be a string!")
+    model_config = SettingsConfigDict(env_prefix="CAVA_DATA_STACK_", env_file=".env")
+
+    # @model_validator(mode='after')
+    # def set_sqs(cls, values):
+    #     env_values = values.get('env')
+    #     rabbitmq_uri = env_values.get('RABBITMQ_URI')
+    #     if not isinstance(rabbitmq_uri, str):
+    #         raise TypeError("RABBITMQ_URI must be a string!")
         
-        if rabbitmq_uri.startswith('sqs://'):
-            env_values.update({
-                'REGION': values.get('region'),
-            })
-            values.update({
-                'env': env_values,
-                'is_sqs': True
-            })
-            return values
-        return values
+    #     if rabbitmq_uri.startswith('sqs://'):
+    #         env_values.update({
+    #             'REGION': values.get('region'),
+    #         })
+    #         values.update({
+    #             'env': env_values,
+    #             'is_sqs': True
+    #         })
+    #         return values
+    #     return values

--- a/resources/aws/cdk/config.py
+++ b/resources/aws/cdk/config.py
@@ -2,7 +2,6 @@
 
 from typing import Dict, List, Optional
 
-from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -51,20 +50,3 @@ class StackSettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="CAVA_DATA_STACK_", env_file=".env")
 
-    # @model_validator(mode='after')
-    # def set_sqs(cls, values):
-    #     env_values = values.get('env')
-    #     rabbitmq_uri = env_values.get('RABBITMQ_URI')
-    #     if not isinstance(rabbitmq_uri, str):
-    #         raise TypeError("RABBITMQ_URI must be a string!")
-        
-    #     if rabbitmq_uri.startswith('sqs://'):
-    #         env_values.update({
-    #             'REGION': values.get('region'),
-    #         })
-    #         values.update({
-    #             'env': env_values,
-    #             'is_sqs': True
-    #         })
-    #         return values
-    #     return values

--- a/resources/aws/lambda/Dockerfile
+++ b/resources/aws/lambda/Dockerfile
@@ -1,16 +1,19 @@
+ARG PYTHON_VERSION=3.11
+
 FROM amazon/aws-lambda-python:3.8
 
-LABEL maintainer="Landung Setiawan"
-RUN yum update -y && \
-    yum install -y python3 python3-dev python3-pip gcc libcurl-devel libssh2-devel nss-devel which git && \
-    rm -Rf /var/cache/yum
-RUN which curl-config
-ENV LD_LIBRARY_PATH=/usr/lib
-ENV PYCURL_CURL_CONFIG=/usr/bin/curl-config
-ENV PYCURL_SSL_LIBRARY=nss
-COPY ./ /tmp/app
-RUN pip install /tmp/app
-RUN pip install mangum>=0.10.0
-RUN rm -rf /tmp/app
-COPY resources/aws/lambda/handler.py ./
-CMD ["handler.handler"]
+WORKDIR /tmp
+
+RUN pip install pip -U
+RUN pip install "titiler.application==0.17.0" "mangum>=0.10.0" -t /asset --no-binary pydantic
+
+# Reduce package size and remove useless files
+RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//'); cp $f $n; done;
+RUN cd /asset && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
+RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
+RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
+RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
+
+COPY lambda/handler.py /asset/handler.py
+
+CMD ["echo", "hello world"]

--- a/resources/aws/package-lock.json
+++ b/resources/aws/package-lock.json
@@ -9,73 +9,633 @@
             "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
-                "cdk": "1.152.0"
+                "@aws-cdk/aws-lambda-python-alpha": "^2.0.0-alpha.11",
+                "aws-cdk-lib": "^2.0.0",
+                "constructs": "^10.0.0"
+            },
+            "peerDependencies": {
+                "aws-cdk-lib": "^2.0.0",
+                "constructs": "^10.0.0"
             }
         },
-        "node_modules/aws-cdk": {
-            "version": "1.152.0",
-            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.152.0.tgz",
-            "integrity": "sha512-iAuTEBAZp78gmW6w2VKCWZ2/pHFc6OAIz07cO4xiTImDWYy5uKyN+rVOKpy1wdUEUZfcI85eKMeZvFubra8uZA==",
-            "bin": {
-                "cdk": "bin/cdk"
-            },
+        "node_modules/@aws-cdk/asset-awscli-v1": {
+            "version": "2.2.201",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz",
+            "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ=="
+        },
+        "node_modules/@aws-cdk/asset-kubectl-v20": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+            "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+        },
+        "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
+            "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+        },
+        "node_modules/@aws-cdk/aws-lambda-python-alpha": {
+            "version": "2.0.0-rc.24",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.0.0-rc.24.tgz",
+            "integrity": "sha512-XPjIdWJigzCFkYCGCjvdDGyfKzBU26ULf40oMkVAyN5Gr8CJfk+Y0ymM3rY0I7/zGgxVrxC1JhogNdp9HaT04w==",
             "engines": {
                 "node": ">= 10.13.0 <13 || >=13.7.0"
             },
-            "optionalDependencies": {
-                "fsevents": "2.3.2"
+            "peerDependencies": {
+                "aws-cdk-lib": "^2.0.0-rc.24",
+                "constructs": "^10.0.0"
             }
         },
-        "node_modules/cdk": {
-            "version": "1.152.0",
-            "resolved": "https://registry.npmjs.org/cdk/-/cdk-1.152.0.tgz",
-            "integrity": "sha512-ljQi/pLkFyimBkpmV75Xji3J6gstIUHUPeVIRMok+M7E+dA8fiRvSSffF2xrwmZEmc/k676d0YBsODjuhDpoCA==",
+        "node_modules/aws-cdk-lib": {
+            "version": "2.114.1",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.114.1.tgz",
+            "integrity": "sha512-pJy+Sa3+s6K9I0CXYGU8J5jumw9uQEbl8zPK8EMA+A6hP9qb1JN+a8ohyw6a1O1cb4D5S6gwH+hE7Fq7hGPY3A==",
+            "bundleDependencies": [
+                "@balena/dockerignore",
+                "case",
+                "fs-extra",
+                "ignore",
+                "jsonschema",
+                "minimatch",
+                "punycode",
+                "semver",
+                "table",
+                "yaml"
+            ],
             "dependencies": {
-                "aws-cdk": "1.152.0"
+                "@aws-cdk/asset-awscli-v1": "^2.2.201",
+                "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+                "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+                "@balena/dockerignore": "^1.0.2",
+                "case": "1.6.3",
+                "fs-extra": "^11.1.1",
+                "ignore": "^5.3.0",
+                "jsonschema": "^1.4.1",
+                "minimatch": "^3.1.2",
+                "punycode": "^2.3.1",
+                "semver": "^7.5.4",
+                "table": "^6.8.1",
+                "yaml": "1.10.2"
+            },
+            "engines": {
+                "node": ">= 14.15.0"
+            },
+            "peerDependencies": {
+                "constructs": "^10.0.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+            "version": "1.0.2",
+            "inBundle": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/aws-cdk-lib/node_modules/ajv": {
+            "version": "8.12.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/case": {
+            "version": "1.6.3",
+            "inBundle": true,
+            "license": "(MIT OR GPL-3.0-or-later)",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/color-convert": {
+            "version": "2.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/color-name": {
+            "version": "1.1.4",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/aws-cdk-lib/node_modules/concat-map": {
+            "version": "0.0.1",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+            "version": "11.1.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/aws-cdk-lib/node_modules/ignore": {
+            "version": "5.3.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+            "version": "1.4.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+            "version": "4.4.2",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/aws-cdk-lib/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/minimatch": {
+            "version": "3.1.2",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/punycode": {
+            "version": "2.3.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+            "version": "2.0.2",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/semver": {
+            "version": "7.5.4",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
             },
             "bin": {
-                "cdk": "bin/cdk"
+                "semver": "bin/semver.js"
             },
             "engines": {
-                "node": ">= 8.10.0"
+                "node": ">=10"
             }
         },
-        "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
+        "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
             "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/string-width": {
+            "version": "4.2.3",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/table": {
+            "version": "6.8.1",
+            "inBundle": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "ajv": "^8.0.1",
+                "lodash.truncate": "^4.4.2",
+                "slice-ansi": "^4.0.0",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/universalify": {
+            "version": "2.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/uri-js": {
+            "version": "4.4.1",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/yallist": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/aws-cdk-lib/node_modules/yaml": {
+            "version": "1.10.2",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/constructs": {
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
+            "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 16.14.0"
             }
         }
     },
     "dependencies": {
-        "aws-cdk": {
-            "version": "1.152.0",
-            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.152.0.tgz",
-            "integrity": "sha512-iAuTEBAZp78gmW6w2VKCWZ2/pHFc6OAIz07cO4xiTImDWYy5uKyN+rVOKpy1wdUEUZfcI85eKMeZvFubra8uZA==",
+        "@aws-cdk/asset-awscli-v1": {
+            "version": "2.2.201",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz",
+            "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ=="
+        },
+        "@aws-cdk/asset-kubectl-v20": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+            "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+        },
+        "@aws-cdk/asset-node-proxy-agent-v6": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
+            "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+        },
+        "@aws-cdk/aws-lambda-python-alpha": {
+            "version": "2.0.0-rc.24",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.0.0-rc.24.tgz",
+            "integrity": "sha512-XPjIdWJigzCFkYCGCjvdDGyfKzBU26ULf40oMkVAyN5Gr8CJfk+Y0ymM3rY0I7/zGgxVrxC1JhogNdp9HaT04w==",
+            "requires": {}
+        },
+        "aws-cdk-lib": {
+            "version": "2.114.1",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.114.1.tgz",
+            "integrity": "sha512-pJy+Sa3+s6K9I0CXYGU8J5jumw9uQEbl8zPK8EMA+A6hP9qb1JN+a8ohyw6a1O1cb4D5S6gwH+hE7Fq7hGPY3A==",
             "requires": {
-                "fsevents": "2.3.2"
+                "@aws-cdk/asset-awscli-v1": "^2.2.201",
+                "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+                "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+                "@balena/dockerignore": "^1.0.2",
+                "case": "1.6.3",
+                "fs-extra": "^11.1.1",
+                "ignore": "^5.3.0",
+                "jsonschema": "^1.4.1",
+                "minimatch": "^3.1.2",
+                "punycode": "^2.3.1",
+                "semver": "^7.5.4",
+                "table": "^6.8.1",
+                "yaml": "1.10.2"
+            },
+            "dependencies": {
+                "@balena/dockerignore": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "ajv": {
+                    "version": "8.12.0",
+                    "bundled": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.1",
+                    "bundled": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "astral-regex": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "balanced-match": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "case": {
+                    "version": "1.6.3",
+                    "bundled": true
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "bundled": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "bundled": true
+                },
+                "fast-deep-equal": {
+                    "version": "3.1.3",
+                    "bundled": true
+                },
+                "fs-extra": {
+                    "version": "11.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.11",
+                    "bundled": true
+                },
+                "ignore": {
+                    "version": "5.3.0",
+                    "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "bundled": true
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "jsonschema": {
+                    "version": "1.4.1",
+                    "bundled": true
+                },
+                "lodash.truncate": {
+                    "version": "4.4.2",
+                    "bundled": true
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "punycode": {
+                    "version": "2.3.1",
+                    "bundled": true
+                },
+                "require-from-string": {
+                    "version": "2.0.2",
+                    "bundled": true
+                },
+                "semver": {
+                    "version": "7.5.4",
+                    "bundled": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "slice-ansi": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "astral-regex": "^2.0.0",
+                        "is-fullwidth-code-point": "^3.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "4.2.3",
+                    "bundled": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.1"
+                    }
+                },
+                "table": {
+                    "version": "6.8.1",
+                    "bundled": true,
+                    "requires": {
+                        "ajv": "^8.0.1",
+                        "lodash.truncate": "^4.4.2",
+                        "slice-ansi": "^4.0.0",
+                        "string-width": "^4.2.3",
+                        "strip-ansi": "^6.0.1"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "uri-js": {
+                    "version": "4.4.1",
+                    "bundled": true,
+                    "requires": {
+                        "punycode": "^2.1.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "bundled": true
+                },
+                "yaml": {
+                    "version": "1.10.2",
+                    "bundled": true
+                }
             }
         },
-        "cdk": {
-            "version": "1.152.0",
-            "resolved": "https://registry.npmjs.org/cdk/-/cdk-1.152.0.tgz",
-            "integrity": "sha512-ljQi/pLkFyimBkpmV75Xji3J6gstIUHUPeVIRMok+M7E+dA8fiRvSSffF2xrwmZEmc/k676d0YBsODjuhDpoCA==",
-            "requires": {
-                "aws-cdk": "1.152.0"
-            }
-        },
-        "fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "optional": true
+        "constructs": {
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
+            "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ=="
         }
     }
 }

--- a/resources/aws/package.json
+++ b/resources/aws/package.json
@@ -5,7 +5,13 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-      "cdk": "1.152.0"
+      "@aws-cdk/aws-lambda-python-alpha": "^2.0.0-alpha.11",
+      "aws-cdk-lib": "^2.0.0",
+      "constructs": "^10.0.0"
+    },
+    "peerDependencies": {
+      "aws-cdk-lib": "^2.0.0",
+      "constructs": "^10.0.0"
     },
     "scripts": {
       "cdk": "cdk"

--- a/resources/aws/requirements.txt
+++ b/resources/aws/requirements.txt
@@ -1,11 +1,9 @@
 # aws cdk
-aws-cdk.core==1.152.0
-aws-cdk.aws_lambda==1.152.0
-aws-cdk.aws_ec2==1.152.0
-aws-cdk.aws_apigatewayv2==1.152.0
-aws-cdk.aws_apigatewayv2_integrations==1.152.0
-aws-cdk.aws_certificatemanager==1.152.0
+aws-cdk-lib==2.123.0
+aws_cdk-aws_apigatewayv2_alpha==2.94.0a0
+aws_cdk-aws_apigatewayv2_integrations_alpha==2.94.0a0
+constructs>=10.0.0
 
 # pydantic settings
-pydantic
-python-dotenv
+pydantic~=2.0
+pydantic-settings~=2.0


### PR DESCRIPTION
## Overview

This PR updates the cava-data deployment from aws-cdk v1 to v2 and pedantic from v1 to v2. These changes are adapted from [Titiler](https://github.com/developmentseed/titiler/tree/main/deployment). 
