### PR TITLE
Updating requirements.txt dependencies

### DIFF
--- a/resources/aws/package-lock.json
+++ b/resources/aws/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
-                "@aws-cdk/aws-lambda-python-alpha": "^2.0.0-alpha.11",
+                "@aws-cdk/aws-lambda-python-alpha": "^2.140.0-alpha.0",
                 "aws-cdk-lib": "^2.0.0",
                 "constructs": "^10.0.0"
             },
@@ -19,9 +19,9 @@
             }
         },
         "node_modules/@aws-cdk/asset-awscli-v1": {
-            "version": "2.2.201",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz",
-            "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ=="
+            "version": "2.2.202",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+            "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
         },
         "node_modules/@aws-cdk/asset-kubectl-v20": {
             "version": "2.1.2",
@@ -29,26 +29,26 @@
             "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
         },
         "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-            "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
+            "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
         },
         "node_modules/@aws-cdk/aws-lambda-python-alpha": {
-            "version": "2.0.0-rc.24",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.0.0-rc.24.tgz",
-            "integrity": "sha512-XPjIdWJigzCFkYCGCjvdDGyfKzBU26ULf40oMkVAyN5Gr8CJfk+Y0ymM3rY0I7/zGgxVrxC1JhogNdp9HaT04w==",
+            "version": "2.140.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.140.0-alpha.0.tgz",
+            "integrity": "sha512-tJ4GK4fIGjfHEN38NTYnxiovCB7xoR4sZRQtN9XefzpJKKllKxYMXLMF1PRRiOpewLjEtgupN5JG8Kfl/SRxcQ==",
             "engines": {
-                "node": ">= 10.13.0 <13 || >=13.7.0"
+                "node": ">= 14.15.0"
             },
             "peerDependencies": {
-                "aws-cdk-lib": "^2.0.0-rc.24",
+                "aws-cdk-lib": "^2.140.0",
                 "constructs": "^10.0.0"
             }
         },
         "node_modules/aws-cdk-lib": {
-            "version": "2.114.1",
-            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.114.1.tgz",
-            "integrity": "sha512-pJy+Sa3+s6K9I0CXYGU8J5jumw9uQEbl8zPK8EMA+A6hP9qb1JN+a8ohyw6a1O1cb4D5S6gwH+hE7Fq7hGPY3A==",
+            "version": "2.140.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.140.0.tgz",
+            "integrity": "sha512-wepu+u63LTxnIfW/IPr+V5Mx1T9jq8HRxhPynYPQKFYaKfOV+6HtJGxkuAEg2CWXk0rx2Btal/BCLjYQovI92Q==",
             "bundleDependencies": [
                 "@balena/dockerignore",
                 "case",
@@ -59,21 +59,23 @@
                 "punycode",
                 "semver",
                 "table",
-                "yaml"
+                "yaml",
+                "mime-types"
             ],
             "dependencies": {
-                "@aws-cdk/asset-awscli-v1": "^2.2.201",
+                "@aws-cdk/asset-awscli-v1": "^2.2.202",
                 "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-                "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+                "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
                 "@balena/dockerignore": "^1.0.2",
                 "case": "1.6.3",
-                "fs-extra": "^11.1.1",
-                "ignore": "^5.3.0",
+                "fs-extra": "^11.2.0",
+                "ignore": "^5.3.1",
                 "jsonschema": "^1.4.1",
+                "mime-types": "^2.1.35",
                 "minimatch": "^3.1.2",
                 "punycode": "^2.3.1",
-                "semver": "^7.5.4",
-                "table": "^6.8.1",
+                "semver": "^7.6.0",
+                "table": "^6.8.2",
                 "yaml": "1.10.2"
             },
             "engines": {
@@ -89,14 +91,14 @@
             "license": "Apache-2.0"
         },
         "node_modules/aws-cdk-lib/node_modules/ajv": {
-            "version": "8.12.0",
+            "version": "8.13.0",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "fast-deep-equal": "^3.1.1",
+                "fast-deep-equal": "^3.1.3",
                 "json-schema-traverse": "^1.0.0",
                 "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
+                "uri-js": "^4.4.1"
             },
             "funding": {
                 "type": "github",
@@ -187,7 +189,7 @@
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-            "version": "11.1.1",
+            "version": "11.2.0",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -205,7 +207,7 @@
             "license": "ISC"
         },
         "node_modules/aws-cdk-lib/node_modules/ignore": {
-            "version": "5.3.0",
+            "version": "5.3.1",
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -260,6 +262,25 @@
                 "node": ">=10"
             }
         },
+        "node_modules/aws-cdk-lib/node_modules/mime-db": {
+            "version": "1.52.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/mime-types": {
+            "version": "2.1.35",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/aws-cdk-lib/node_modules/minimatch": {
             "version": "3.1.2",
             "inBundle": true,
@@ -288,7 +309,7 @@
             }
         },
         "node_modules/aws-cdk-lib/node_modules/semver": {
-            "version": "7.5.4",
+            "version": "7.6.0",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -342,7 +363,7 @@
             }
         },
         "node_modules/aws-cdk-lib/node_modules/table": {
-            "version": "6.8.1",
+            "version": "6.8.2",
             "inBundle": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -397,9 +418,9 @@
     },
     "dependencies": {
         "@aws-cdk/asset-awscli-v1": {
-            "version": "2.2.201",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz",
-            "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ=="
+            "version": "2.2.202",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+            "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
         },
         "@aws-cdk/asset-kubectl-v20": {
             "version": "2.1.2",
@@ -407,33 +428,34 @@
             "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
         },
         "@aws-cdk/asset-node-proxy-agent-v6": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-            "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
+            "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
         },
         "@aws-cdk/aws-lambda-python-alpha": {
-            "version": "2.0.0-rc.24",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.0.0-rc.24.tgz",
-            "integrity": "sha512-XPjIdWJigzCFkYCGCjvdDGyfKzBU26ULf40oMkVAyN5Gr8CJfk+Y0ymM3rY0I7/zGgxVrxC1JhogNdp9HaT04w==",
+            "version": "2.140.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.140.0-alpha.0.tgz",
+            "integrity": "sha512-tJ4GK4fIGjfHEN38NTYnxiovCB7xoR4sZRQtN9XefzpJKKllKxYMXLMF1PRRiOpewLjEtgupN5JG8Kfl/SRxcQ==",
             "requires": {}
         },
         "aws-cdk-lib": {
-            "version": "2.114.1",
-            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.114.1.tgz",
-            "integrity": "sha512-pJy+Sa3+s6K9I0CXYGU8J5jumw9uQEbl8zPK8EMA+A6hP9qb1JN+a8ohyw6a1O1cb4D5S6gwH+hE7Fq7hGPY3A==",
+            "version": "2.140.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.140.0.tgz",
+            "integrity": "sha512-wepu+u63LTxnIfW/IPr+V5Mx1T9jq8HRxhPynYPQKFYaKfOV+6HtJGxkuAEg2CWXk0rx2Btal/BCLjYQovI92Q==",
             "requires": {
-                "@aws-cdk/asset-awscli-v1": "^2.2.201",
+                "@aws-cdk/asset-awscli-v1": "^2.2.202",
                 "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-                "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+                "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
                 "@balena/dockerignore": "^1.0.2",
                 "case": "1.6.3",
-                "fs-extra": "^11.1.1",
-                "ignore": "^5.3.0",
+                "fs-extra": "^11.2.0",
+                "ignore": "^5.3.1",
                 "jsonschema": "^1.4.1",
+                "mime-types": "^2.1.35",
                 "minimatch": "^3.1.2",
                 "punycode": "^2.3.1",
-                "semver": "^7.5.4",
-                "table": "^6.8.1",
+                "semver": "^7.6.0",
+                "table": "^6.8.2",
                 "yaml": "1.10.2"
             },
             "dependencies": {
@@ -442,13 +464,13 @@
                     "bundled": true
                 },
                 "ajv": {
-                    "version": "8.12.0",
+                    "version": "8.13.0",
                     "bundled": true,
                     "requires": {
-                        "fast-deep-equal": "^3.1.1",
+                        "fast-deep-equal": "^3.1.3",
                         "json-schema-traverse": "^1.0.0",
                         "require-from-string": "^2.0.2",
-                        "uri-js": "^4.2.2"
+                        "uri-js": "^4.4.1"
                     }
                 },
                 "ansi-regex": {
@@ -506,7 +528,7 @@
                     "bundled": true
                 },
                 "fs-extra": {
-                    "version": "11.1.1",
+                    "version": "11.2.0",
                     "bundled": true,
                     "requires": {
                         "graceful-fs": "^4.2.0",
@@ -519,7 +541,7 @@
                     "bundled": true
                 },
                 "ignore": {
-                    "version": "5.3.0",
+                    "version": "5.3.1",
                     "bundled": true
                 },
                 "is-fullwidth-code-point": {
@@ -553,6 +575,17 @@
                         "yallist": "^4.0.0"
                     }
                 },
+                "mime-db": {
+                    "version": "1.52.0",
+                    "bundled": true
+                },
+                "mime-types": {
+                    "version": "2.1.35",
+                    "bundled": true,
+                    "requires": {
+                        "mime-db": "1.52.0"
+                    }
+                },
                 "minimatch": {
                     "version": "3.1.2",
                     "bundled": true,
@@ -569,7 +602,7 @@
                     "bundled": true
                 },
                 "semver": {
-                    "version": "7.5.4",
+                    "version": "7.6.0",
                     "bundled": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -601,7 +634,7 @@
                     }
                 },
                 "table": {
-                    "version": "6.8.1",
+                    "version": "6.8.2",
                     "bundled": true,
                     "requires": {
                         "ajv": "^8.0.1",

--- a/resources/aws/package.json
+++ b/resources/aws/package.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-      "@aws-cdk/aws-lambda-python-alpha": "^2.0.0-alpha.11",
+      "@aws-cdk/aws-lambda-python-alpha": "^2.140.0-alpha.0",
       "aws-cdk-lib": "^2.0.0",
       "constructs": "^10.0.0"
     },

--- a/resources/aws/requirements.txt
+++ b/resources/aws/requirements.txt
@@ -1,9 +1,7 @@
 # aws cdk
-aws-cdk-lib==2.123.0
-aws_cdk-aws_apigatewayv2_alpha==2.94.0a0
-aws_cdk-aws_apigatewayv2_integrations_alpha==2.94.0a0
+aws-cdk-lib>=2.123.0
 constructs>=10.0.0
 
 # pydantic settings
-pydantic~=2.0
-pydantic-settings~=2.0
+pydantic>=2.0
+pydantic-settings>=2.0


### PR DESCRIPTION
Since the aws_cdk-aws_apigatewayv2_alpha and aws_cdk-aws_apigatewayv2_integrations_alpha dependencies are deprecated, I removed them from requirements.txt and loosened some of the required aws_cdk-lib version to allow the Lambda deployments to run.